### PR TITLE
bugfix/frontend-questions-form-reset

### DIFF
--- a/frontend/src/app/questions/components/QuestionForm.tsx
+++ b/frontend/src/app/questions/components/QuestionForm.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { CheckIcon, ChevronsUpDown } from "lucide-react";
 import React from "react";
 import { useForm } from "react-hook-form";
@@ -58,7 +56,7 @@ const QuestionForm: React.FC<QuestionFormProps> = ({
     defaultValues: {
       title: "",
       link: "",
-      difficulty: undefined,
+      difficulty: "",
       description: "",
       categories: [],
     },
@@ -77,6 +75,7 @@ const QuestionForm: React.FC<QuestionFormProps> = ({
     );
 
     if (isDuplicate) {
+      console.log(currentQuestions);
       alert("Error: Duplicate title or URL found.");
       return;
     }
@@ -193,9 +192,10 @@ const QuestionForm: React.FC<QuestionFormProps> = ({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Difficulty</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select onValueChange={field.onChange} value={field.value}>
                 <FormControl>
                   <SelectTrigger>
+                    {field.value === "" && "Select a difficulty"}
                     <SelectValue placeholder="Select a difficulty" />
                   </SelectTrigger>
                 </FormControl>

--- a/frontend/src/app/questions/types/question.schema.ts
+++ b/frontend/src/app/questions/types/question.schema.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
-const Difficulty = z
-  .enum(["Easy", "Medium", "Hard"])
-  .refine((value) => value !== undefined, {
-    message: "Difficulty selection is required",
-  });
+// need to include "" as part of possibility Difficulty values due to shadcn bug with select
+// see: https://github.com/shadcn-ui/ui/issues/549
+const Difficulty = z.enum(["", "Easy", "Medium", "Hard"]);
 
 const Question = z.object({
   title: z.string().nonempty({ message: "Title is required" }),


### PR DESCRIPTION
Currently, when resetting the form, the `Difficulty` select field does not reset properly, due to an issue with shadcn and useForm, see [shadcn-ui/ui/issues/549](https://github.com/shadcn-ui/ui/issues/549).

To fix this issue, the default value of the `Select` field has been set to `""` instead of `undefined`, see [radix-ui/primitives/pull/2174](https://github.com/radix-ui/primitives/pull/2174).