### PR TITLE
feature(frontend): global notifications hook and loading button

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
+import { Loader2 } from "lucide-react"
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -37,17 +38,25 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  isLoading?: boolean;
+  loadingText?: string;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, disabled, isLoading, loadingText, children, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
+    const isDisabled = isLoading || disabled
+    const displayLoadingText = loadingText || "Submitting";
+    
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        disabled={isDisabled}
         {...props}
-      />
+      >
+        {isLoading ? <><Loader2 className="mr-2 animate-spin" /><p>{displayLoadingText}</p></> : children}
+      </Comp>
     );
   },
 );

--- a/frontend/src/features/users/components/EditUserProfileForm.tsx
+++ b/frontend/src/features/users/components/EditUserProfileForm.tsx
@@ -39,18 +39,47 @@ import {
 import { UserSchema } from "../types/user.schema";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 
+import { useApiNotifications } from "@/hooks/useApiNotifications";
+
 export function EditUserProfileForm({ userId }: { userId: number }) {
-  const { data: user, isError, isLoading } = useGetUserByIdQuery(userId);
+  const {
+    data: user,
+    isError: isGetUserError,
+    isLoading: isGetUserLoading,
+  } = useGetUserByIdQuery(userId);
   const dispatch = useDispatch();
-  const [updateUser] = useUpdateUserMutation();
-  const [deleteUser] = useDeleteUserMutation();
+  const [
+    updateUser,
+    {
+      isSuccess: isUpdateSuccess,
+      isLoading: isUpdateLoading,
+      isError: isUpdateError,
+    },
+  ] = useUpdateUserMutation();
+  const [
+    deleteUser,
+    {
+      isSuccess: isDeleteSuccess,
+      isLoading: isDeleteLoading,
+      isError: isDeleteError,
+    },
+  ] = useDeleteUserMutation();
 
-  if (isError) {
+  useApiNotifications({
+    isSuccess: isUpdateSuccess,
+    isError: isUpdateError,
+    successMessage: "Successfully updated user profile!",
+  });
+
+  useApiNotifications({
+    isSuccess: isDeleteSuccess,
+    isError: isDeleteError,
+    successMessage: "Successfully deleted user!",
+  });
+
+  if (isGetUserError) {
+    // TODO: Redirect user to error page
     throw new Error("No such User");
-  }
-
-  if (isLoading) {
-    return <div>Loading</div>;
   }
 
   const form = useForm<z.infer<typeof UserSchema>>({
@@ -165,7 +194,12 @@ export function EditUserProfileForm({ userId }: { userId: number }) {
                   )}
                 />
                 <DialogClose className="w-full">
-                  <Button type="submit" className="w-full">
+                  <Button
+                    isLoading={isUpdateLoading}
+                    loadingText="Submitting"
+                    type="submit"
+                    className="w-full"
+                  >
                     Submit
                   </Button>
                 </DialogClose>

--- a/frontend/src/features/users/components/OnboardingForm.tsx
+++ b/frontend/src/features/users/components/OnboardingForm.tsx
@@ -28,11 +28,20 @@ import { useCreateUserMutation } from "@/services/userApi";
 
 import { CreateUserSchema } from "../types/onboarding.schema";
 
+import { useApiNotifications } from "@/hooks/useApiNotifications";
+
 export const OnboardingForm = () => {
   const { data: session } = useSession();
   const router = useRouter();
   const dispatch = useDispatch();
-  const [createUser] = useCreateUserMutation();
+  const [createUser, { isLoading, isError, isSuccess }] =
+    useCreateUserMutation();
+
+  useApiNotifications({
+    isSuccess,
+    isError,
+    successMessage: "Successfully updated user profile!",
+  });
 
   if (!session) {
     <div>Loading</div>;
@@ -126,7 +135,13 @@ export const OnboardingForm = () => {
             )}
           />
           <div className="flex w-full gap-5">
-            <Button type="submit">Submit</Button>
+            <Button
+              isLoading={isLoading}
+              loadingText="Submitting"
+              type="submit"
+            >
+              Submit
+            </Button>
           </div>
         </form>
       </Form>

--- a/frontend/src/hooks/useApiNotifications.tsx
+++ b/frontend/src/hooks/useApiNotifications.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { NotificationType, setNotification } from "@/features/notifications";
+
+type UseApiNotificationsConfig = {
+  isSuccess?: boolean;
+  isError?: boolean;
+  successMessage?: string;
+  errorMessage?: string;
+};
+
+export const useApiNotifications = ({
+  isSuccess,
+  isError,
+  successMessage = "Success!",
+  errorMessage = "An unexpected error occurred!",
+}: UseApiNotificationsConfig) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (isSuccess) {
+      const notificationPayload = {
+        type: NotificationType.SUCCESS,
+        value: successMessage,
+      };
+      dispatch(setNotification(notificationPayload));
+    } else if (isError) {
+      const notificationPayload = {
+        type: NotificationType.ERROR,
+        value: errorMessage,
+      };
+      dispatch(setNotification(notificationPayload));
+    }
+  }, [dispatch, isError, isSuccess, successMessage, errorMessage]);
+};

--- a/frontend/src/services/userApi.ts
+++ b/frontend/src/services/userApi.ts
@@ -1,6 +1,5 @@
 import { rootApi } from "@/app/RootApi.ts";
 
-import { NotificationType, setNotification } from "@/features/notifications";
 import type { User } from "@/features/users";
 
 rootApi.enhanceEndpoints({ addTagTypes: ["User"] });
@@ -21,13 +20,6 @@ const userApi = rootApi.injectEndpoints({
         method: "POST",
         body: newUser,
       }),
-      async onCacheEntryAdded(arg, { dispatch }) {
-        const notificationPayload = {
-          type: NotificationType.SUCCESS,
-          value: "Successfully updated profile",
-        };
-        dispatch(setNotification(notificationPayload));
-      },
     }),
     updateUser: build.mutation<User, Partial<User>>({
       query: (userData) => ({
@@ -37,13 +29,6 @@ const userApi = rootApi.injectEndpoints({
       }),
       // @ts-expect-error
       invalidatesTags: ["User"],
-      async onCacheEntryAdded(_, { dispatch }) {
-        const notificationPayload = {
-          type: NotificationType.SUCCESS,
-          value: "Successfully updated profile",
-        };
-        dispatch(setNotification(notificationPayload));
-      },
     }),
     deleteUser: build.mutation<void, number>({
       query: (userId) => ({
@@ -52,13 +37,6 @@ const userApi = rootApi.injectEndpoints({
       }),
       // @ts-expect-error
       invalidatesTags: ["User"],
-      async onCacheEntryAdded(_, { dispatch }) {
-        const notificationPayload = {
-          type: NotificationType.SUCCESS,
-          value: "Successfully deleted user",
-        };
-        dispatch(setNotification(notificationPayload));
-      },
     }),
   }),
   overrideExisting: false,


### PR DESCRIPTION
## Summary
### Global Notifications Hook `/hooks/useApiNotifications`
- Refactor notifications dispatch logic from the `userApi` service to each component which is sending. This aims to enforce single responsibility principle, where `userApi` is solely responsible for calling the apis, and components are responsible for rendering – thus rendering the notifications
- Create a `useApiNotifications` hook, that allows any component to pass in a api state i.e. `isSuccess`, `isError` and dispatches the appropriate notifications actions. Users of the hook can optionally pass in messages for each state i.e. `successNotification`, `errorNotification`. 

### Loading Button `/components/ui/button`
- Added `isLoading` support to the shared `button` component. Users can optionally provide a `loadingText` to the button to render their desired loading text.