### PR TITLE
feat: dockerise question-service

### DIFF
--- a/services/question-service/.dockerignore
+++ b/services/question-service/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+Dockerfile
+.dockerignore

--- a/services/question-service/Dockerfile
+++ b/services/question-service/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20
+
+WORKDIR /app
+
+COPY package.json ./
+
+RUN npm install
+
+COPY . .
+
+CMD [ "npm", "run", "dev" ]

--- a/services/question-service/compose-dev.yaml
+++ b/services/question-service/compose-dev.yaml
@@ -1,0 +1,11 @@
+services:
+  app:
+    entrypoint:
+    - sleep
+    - infinity
+    image: docker/dev-environments-default:stable-1
+    init: true
+    volumes:
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock

--- a/services/question-service/compose-dev.yaml
+++ b/services/question-service/compose-dev.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    entrypoint:
+    - sleep
+    - infinity
+    image: docker/dev-environments-default:stable-1
+    init: true
+    volumes:
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+

--- a/services/question-service/docker-compose.yml
+++ b/services/question-service/docker-compose.yml
@@ -1,0 +1,29 @@
+# docker-compose.yml
+
+version: '3.8'
+services:
+  backend:
+    container_name: question-service
+    build: .
+    environment:
+      - DATABASE_URL=mongodb://mongodb-user:mongodb-pass@question-db-container:27017/question-db?authSource=admin&directConnection=true
+      - PORT=3001
+    deploy:
+      restart_policy:
+        condition: on-failure
+    ports:
+      - '3001:3001'
+      
+  mongodb:
+    container_name: question-db-container
+    restart: on-failure
+    image: bitnami/mongodb:4.4
+    environment:
+      MONGODB_ADVERTISED_HOSTNAME: question-db-container
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_ROOT_USER: mongodb-user
+      MONGODB_ROOT_PASSWORD: mongodb-pass
+      MONGO_INITDB_DATABASE: question-db
+      MONGODB_REPLICA_SET_KEY: replicasetkey123
+    ports:
+      - '27017:27017'

--- a/services/question-service/docker-compose.yml
+++ b/services/question-service/docker-compose.yml
@@ -1,0 +1,37 @@
+# docker-compose.yml
+
+version: '3.8'
+services:
+  backend:
+    container_name: question-service
+    build: .
+    environment:
+      - DATABASE_URL=mongodb://mongodb-user:mongodb-pass@question-db-container:27017/question-db?authSource=admin&directConnection=true
+      - PORT=5001
+    deploy:
+      restart_policy:
+        condition: on-failure
+    ports:
+      - '5001:5001'
+      
+  mongodb:
+    container_name: question-db-container
+    restart: on-failure
+    image: bitnami/mongodb:4.4
+    environment:
+      MONGODB_ADVERTISED_HOSTNAME: question-db-container
+      MONGODB_REPLICA_SET_MODE: primary
+      MONGODB_ROOT_USER: mongodb-user
+      MONGODB_ROOT_PASSWORD: mongodb-pass
+      MONGO_INITDB_DATABASE: question-db
+      MONGODB_REPLICA_SET_KEY: replicasetkey123
+
+    volumes:
+      - 'mongodb_master_data:/bitnami'
+
+    ports:
+      - '27017:27017'
+
+volumes:
+  mongodb_master_data:
+    driver: local

--- a/services/question-service/entry-points/api/routes.ts
+++ b/services/question-service/entry-points/api/routes.ts
@@ -58,4 +58,12 @@ export default function defineRoutes(expressApp: express.Application) {
   });
 
   expressApp.use("/question", router);
+
+  expressApp.get("/healthz", async (req, res, next) => {
+    try {
+      res.status(200).end("Healthy");
+    } catch (error) {
+      next(error);
+    }
+  });
 }

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -1,6 +1,7 @@
 {
   "name": "question-service",
   "scripts": {
+    "predev": "npx prisma generate && npx prisma db push",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "ts-node-dev start.ts",
     "lint:fix": "eslint --ext .ts --fix ."

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -2,6 +2,7 @@
   "name": "question-service",
   "scripts": {
     "postinstall": "prisma generate",
+    "predev": "npx prisma generate && npx prisma db push",
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "ts-node-dev src/start.ts",
     "lint:fix": "eslint --ext .ts --fix .",

--- a/services/question-service/src/entry-points/api/routes.ts
+++ b/services/question-service/src/entry-points/api/routes.ts
@@ -58,4 +58,12 @@ export default function defineRoutes(expressApp: express.Application) {
   });
 
   expressApp.use("/question", router);
+
+  expressApp.get("/healthz", async (req, res, next) => {
+    try {
+      res.status(200).end("Healthy");
+    } catch (error) {
+      next(error);
+    }
+  });
 }


### PR DESCRIPTION
When you run docker-compose up for the first time the mongodb container takes a while to finish making the db primary, so the question-service container would keep failing and retrying until it works. Tried a bunch of stuff like 
```
depends on:
  mongodb:
    condition: service_healthy
```
but not too sure how to implement healthcheck that checks if mongodb db is primary (also technically isnt the most appropriate way to use healthcheck)

