### PR TITLE
chore: [collab-service] add cache for reconnection

### DIFF
--- a/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
+++ b/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
@@ -59,10 +59,12 @@ export default function SyncedEditor({ roomId }: { roomId: string }) {
       setEditorContent(content);
     });
 
-    socket.on("message", (content: Message) => {
-      console.log(`incoming message ${content.username}: ${content.content}`);
+    socket.on("message", (messages: Message[]) => {
+      messages.forEach((message) => {
+        console.log(`incoming message ${message.username}: ${message.content}`);
+      });
       // required to reference the most recent state of chatMessages
-      setChatMessages((prevMessages) => [...prevMessages, content]);
+      setChatMessages((prevMessages) => [...prevMessages, ...messages]);
     });
     socketRef.current = socket;
   }, []);
@@ -103,12 +105,11 @@ export default function SyncedEditor({ roomId }: { roomId: string }) {
   };
 
   const sendMessage = (value: string | undefined) => {
-    if (socketRef.current) {
+    if (socketRef.current && value) {
       console.log("sending ", value, "to ", roomId);
       socketRef.current.emit("message", {
-        content: value,
         to: roomId,
-        from: currentUser,
+        message: { username: currentUser, content: value } as Message,
       });
       setChatMessages((messages) => [
         ...messages,

--- a/services/collab-service/server.ts
+++ b/services/collab-service/server.ts
@@ -5,8 +5,6 @@ import { Server } from "socket.io";
 
 import type { Message } from "./types";
 
-// import { errorHandler } from "../../errorHandler";
-
 const cors = require("cors");
 
 let connection: Server;
@@ -147,8 +145,6 @@ async function startWebServer(): Promise<AddressInfo> {
   expressApp.use(cors());
   expressApp.use(express.urlencoded({ extended: true }));
   expressApp.use(express.json());
-  // defineRoutes(expressApp);
-  // expressApp.use(errorHandler);
   const APIAddress = await openConnection(expressApp);
   return APIAddress;
 }

--- a/services/collab-service/server.ts
+++ b/services/collab-service/server.ts
@@ -3,11 +3,16 @@ import { createServer } from "http";
 import type { AddressInfo } from "net";
 import { Server } from "socket.io";
 
+import type { Message } from "./types";
+
 // import { errorHandler } from "../../errorHandler";
 
 const cors = require("cors");
 
 let connection: Server;
+const codeCache: Map<string, string> = new Map();
+const messageCache: Map<string, Message[]> = new Map();
+const timeouts: Map<string, NodeJS.Timeout> = new Map();
 
 const setupSocket = (io: Server) => {
   const getConnectedUsers = (roomId: string) =>
@@ -51,43 +56,63 @@ const setupSocket = (io: Server) => {
         .then((users) => {
           socket.emit("users", users);
         });
+      if (codeCache.has(roomId)) {
+        socket.emit("code_update", codeCache.get(roomId));
+      }
+      if (messageCache.has(roomId)) {
+        socket.emit("message", messageCache.get(roomId));
+      }
+      if (timeouts.has(roomId)) {
+        console.log(`resetting timeout for room: ${roomId}`);
+        clearTimeout(timeouts.get(roomId));
+        timeouts.delete(roomId);
+      }
     });
 
     socket.on(
       "code_update",
       ({ content, to }: { content: string; to: string }) => {
         socket.to(to).emit("code_update", content);
+        codeCache.set(to, content);
       },
     );
 
     socket.on(
       "message",
-      ({
-        content,
-        to,
-        from,
-      }: {
-        content: string;
-        to: string;
-        from: string;
-      }) => {
-        console.log(`received message: ${content}`);
-        socket.to(to).emit("message", {
-          username: from,
-          content,
-        });
+      ({ to, message }: { to: string; message: Message }) => {
+        console.log(
+          `received message: "${message.content}" from: ${message.username}`,
+        );
+        socket.to(to).emit("message", [message]);
+        if (messageCache.has(to)) {
+          messageCache.get(to)!.push(message);
+        } else {
+          messageCache.set(to, [message]);
+        }
       },
     );
 
     socket.on("disconnecting", () => {
-      console.log("disconnected");
       for (const room of socket.rooms) {
         if (room === socket.id) {
+          console.log("disconnecting from home socket");
           continue;
+        } else {
+          console.log(`disconnecting from room: ${room}`);
         }
         getConnectedUsers(room)
           .catch((e) => console.error(e))
           .then((users) => {
+            if (!users || users.length === 1) {
+              console.log(`setting cache timeout for empty room: ${room}`);
+              const clearRoomCacheTimeout = setTimeout(() => {
+                messageCache.delete(room);
+                codeCache.delete(room);
+                console.log(`cleared caches for room: ${room}`);
+              }, 600000);
+              timeouts.set(room, clearRoomCacheTimeout);
+              return;
+            }
             const remainingUsers = users?.filter(
               (user) => user.userID !== socket.id,
             );

--- a/services/collab-service/types.ts
+++ b/services/collab-service/types.ts
@@ -16,6 +16,11 @@ export type QuestionFilter = {
   categories: string[] | undefined;
 };
 
+export type Message = {
+  username: string;
+  content: string;
+};
+
 export enum Difficulty {
   Easy = "Easy",
   Medium = "Medium",

--- a/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
+++ b/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
@@ -17,7 +17,8 @@ export function SyncedEditor({ roomId }: { roomId: string }) {
   const [editorContent, setEditorContent] = useState<string>(
     "// add your code here",
   );
-  const [numConnectedUsers, setNumConnectedUsers] = useState<number>([]);
+
+  const [numConnectedUsers, setNumConnectedUsers] = useState<number>();
   const [chatMessages, setChatMessages] = useState<Message[]>([]);
   const socketRef = useRef<Socket>();
 

--- a/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
+++ b/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
@@ -12,7 +12,7 @@ import { QuestionDisplay } from "../QuestionDisplay";
 import type { Message, User } from "../types";
 import { ChatWindow } from "./ChatWindow";
 
-export default function SyncedEditor({ roomId }: { roomId: string }) {
+export function SyncedEditor({ roomId }: { roomId: string }) {
   const auth = useSelector(selectAuthData);
   const monaco = useMonaco();
   const URL = "http://localhost:4001";

--- a/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
+++ b/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
@@ -18,7 +18,7 @@ export function SyncedEditor({ roomId }: { roomId: string }) {
     "// add your code here",
   );
 
-  const [numConnectedUsers, setNumConnectedUsers] = useState<number>();
+  const [numConnectedUsers, setNumConnectedUsers] = useState<number>(0);
   const [chatMessages, setChatMessages] = useState<Message[]>([]);
   const socketRef = useRef<Socket>();
 
@@ -56,7 +56,10 @@ export function SyncedEditor({ roomId }: { roomId: string }) {
         console.log(`incoming message ${message.username}: ${message.content}`);
       });
       // required to reference the most recent state of chatMessages
-      setChatMessages((prevMessages: Message[]) => [...prevMessages, ...messages]);
+      setChatMessages((prevMessages: Message[]) => [
+        ...prevMessages,
+        ...messages,
+      ]);
     });
     socketRef.current = socket;
   }, []);

--- a/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
+++ b/services/frontend/src/features/collab/SyncedEditor/SyncedEditor.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useRef, useState } from "react";
+import { useSelector } from "react-redux";
 import type { Socket } from "socket.io-client";
 import { io } from "socket.io-client";
 
 import { Editor, useMonaco } from "@monaco-editor/react";
 
+import { selectAuthData } from "@/features/auth";
 import { questionsStub } from "@/features/questions/stubs/questions.stub";
 
 import { QuestionDisplay } from "../QuestionDisplay";
 import type { Message, User } from "../types";
 import { ChatWindow } from "./ChatWindow";
 
-export function SyncedEditor({ roomId }: { roomId: string }) {
+export default function SyncedEditor({ roomId }: { roomId: string }) {
+  const auth = useSelector(selectAuthData);
   const monaco = useMonaco();
   const URL = "http://localhost:4001";
   const [currentUser, setCurrentUser] = useState<string>();
@@ -67,7 +70,10 @@ export function SyncedEditor({ roomId }: { roomId: string }) {
   useEffect(() => {
     if (socketRef.current) {
       if (!currentUser) {
-        setCurrentUser(Math.floor(Math.random() * 100).toString());
+        setCurrentUser(
+          auth.currentUser?.id.toString() ??
+            Math.floor(Math.random() * 100).toString(),
+        );
       }
       socketRef.current.auth = {
         username: currentUser,

--- a/services/frontend/src/features/questions/components/QuestionForm.tsx
+++ b/services/frontend/src/features/questions/components/QuestionForm.tsx
@@ -41,8 +41,6 @@ import { Textarea } from "@/components/ui/textarea";
 
 import { cn } from "@/lib/utils";
 
-import { NotificationType, setNotification } from "@/features/notifications";
-
 import { categoriesStub } from "../stubs/categories.stub";
 import { Question } from "../types/question.schema";
 


### PR DESCRIPTION
added caches for collab-service (code and messages)

### Behavioural Changes:
 - Upon joining the room, the user would receive the latest code and all the past messages
   - The only caveat is that the messages sent by the disconnected users would appear to be from another person as the socket-id is reset. I think we could use a fixed user id for the different users instead of the socket id to identify messages, but can address in another PR.
 - If the room is empty (ie all users disconnect), the cache for that room is cleared after 10 minutes
   - If anyone rejoins the room within that time period, the timeout is cleared