### PR TITLE
feat(integration): add language, integrate question-matching services

### DIFF
--- a/services/matching-service/domain/match_validators.ts
+++ b/services/matching-service/domain/match_validators.ts
@@ -1,23 +1,5 @@
-/* eslint-disable no-param-reassign */
 // eslint-disable-next-line import/no-cycle
 import { queues } from "../start";
-import { CATEGORIES, DIFFICULTIES } from "../types";
-
-export function extractDifficulty(difficulty: string) {
-  difficulty = difficulty.toLowerCase();
-  if (DIFFICULTIES.includes(difficulty)) {
-    return difficulty;
-  }
-  return undefined;
-}
-
-export function extractCategory(category: string) {
-  category = category.toLowerCase();
-  if (CATEGORIES.includes(category)) {
-    return category;
-  }
-  return undefined;
-}
 
 export function checkIdExists(id: number) {
   const matches = Array.from(queues.entries());

--- a/services/matching-service/entry_points/api/events.ts
+++ b/services/matching-service/entry_points/api/events.ts
@@ -1,33 +1,39 @@
 import type { Server } from "socket.io";
+import { v4 as uuidv4 } from "uuid";
 
 // eslint-disable-next-line import/no-cycle
-import {
-  checkIdExists,
-  extractCategory,
-  extractDifficulty,
-} from "../../domain/match_validators";
+import { checkIdExists } from "../../domain/match_validators";
 import { queues } from "../../start";
-import type { Match } from "../../types";
+import {
+  Category,
+  Difficulty,
+  Language,
+  type Match,
+  type MatchRequest,
+} from "../../types";
 
 export function defineEventListeners(io: Server) {
   io.on("connection", (socket) => {
     socket.emit("reply", "hello from server");
 
-    socket.on("register", (msg) => {
-      console.log(`A NEW USER WITH ID ${msg.id} JOINED!`);
-
-      const difficulty = extractDifficulty(msg.difficulty);
-      const category = extractCategory(msg.category);
+    socket.on("register", (msg: MatchRequest) => {
+      console.log(`${JSON.stringify(msg)} joined the queue!`);
 
       // Check Valid Difficulty
-      if (difficulty === undefined) {
+      if (Difficulty[msg.difficulty] === undefined) {
         socket.emit("error", "Invalid Difficulty!");
         return;
       }
 
       // Check valid Category
-      if (category === undefined) {
+      if (Category[msg.category] === undefined) {
         socket.emit("error", "Invalid Category!");
+        return;
+      }
+
+      // Check valid Language
+      if (Language[msg.language] === undefined) {
+        socket.emit("error", "Invalid Language!");
         return;
       }
 
@@ -37,13 +43,18 @@ export function defineEventListeners(io: Server) {
         return;
       }
 
+      const difficulty = msg.difficulty.toString();
+      const category = msg.category.toString();
+      const language = msg.language.toString();
+
       // Find match if exists, else create new queue and wait.
-      const matchName = difficulty + category; // e.g. easyrecursion
+      const matchName = difficulty + category + language; // e.g. easyrecursionjavascript
 
       const thisMatch = {
         id: msg.id,
-        difficulty,
-        category,
+        difficulty: msg.difficulty,
+        category: msg.category,
+        language: msg.language,
         sockAddr: socket.id,
       };
 
@@ -57,20 +68,39 @@ export function defineEventListeners(io: Server) {
         // Match found, remove from queues. (If peer connection lost => delete the queue and replace with current user.)
         queues.delete(matchName);
         if (peerSocket) {
-          console.log("WE FOUND A MATCH!");
+          console.log("match found");
 
-          const peerID = thisQueue.id;
+          const params = new URLSearchParams({
+            difficulty,
+            category,
+            getOne: "true",
+          });
 
-          // Emit on peer user's socket
-          peerSocket.emit(
-            "success",
-            `You have been paired with User ${msg.id}`,
-          );
-          peerSocket.disconnect();
-
-          // Emit on this user's socket
-          socket.emit("success", `You have been paired with User ${peerID}.`);
-          socket.disconnect();
+          fetch(`http://localhost:5001/question/?${params.toString()}`)
+            // eslint-disable-next-line consistent-return
+            .then((response) => {
+              if (response.headers.get("Content-Length") === "0") {
+                console.log("no question found");
+                io.to(peerSockAddr)
+                  .to(socket.id)
+                  .emit("error", "No questions meet your provided criteria");
+              } else {
+                return response.json();
+              }
+            })
+            .then((json) => {
+              if (json) {
+                console.log(json);
+                const roomId = uuidv4();
+                io.to(peerSockAddr).to(socket.id).emit("match", {
+                  question: json,
+                  roomId,
+                  language,
+                });
+              }
+              peerSocket.disconnect();
+              socket.disconnect();
+            });
         } else {
           console.log("Cannot find peer socket!");
           queues.set(matchName, thisMatch);
@@ -80,11 +110,11 @@ export function defineEventListeners(io: Server) {
         queues.set(matchName, thisMatch);
 
         // Wait
-        const DELAY = 5000;
+        const DELAY = 120000;
         setTimeout(() => {
           if (queues.has(matchName)) {
             queues.delete(matchName);
-            console.log("FAILURE!");
+            console.log("matching timed out");
             socket.emit("error", "Sorry, we could not find you a match!");
             socket.disconnect();
           }

--- a/services/matching-service/package-lock.json
+++ b/services/matching-service/package-lock.json
@@ -8,10 +8,12 @@
       "dependencies": {
         "@types/express": "^4.17.17",
         "express": "^4.18.2",
-        "socket.io": "^4.7.2"
+        "socket.io": "^4.7.2",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/node": "^20.8.3",
+        "@types/uuid": "^9.0.6",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
         "eslint": "^8.51.0",
@@ -378,6 +380,12 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
+      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4428,6 +4436,18 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/services/matching-service/package.json
+++ b/services/matching-service/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.8.3",
+    "@types/uuid": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "eslint": "^8.51.0",
@@ -29,6 +30,7 @@
   "dependencies": {
     "@types/express": "^4.17.17",
     "express": "^4.18.2",
-    "socket.io": "^4.7.2"
+    "socket.io": "^4.7.2",
+    "uuid": "^9.0.1"
   }
 }

--- a/services/matching-service/types.ts
+++ b/services/matching-service/types.ts
@@ -1,19 +1,40 @@
-export interface Match {
+export type Match = {
   id: number;
-  difficulty: string;
-  category: string;
+  difficulty: Difficulty;
+  category: Category;
   sockAddr: string;
+  language: Language;
+};
+
+export type MatchRequest = Omit<Match, "sockAddr">;
+
+export enum Difficulty {
+  Easy,
+  Medium,
+  Hard,
 }
 
-export const CATEGORIES = [
-  "strings",
-  "algorithms",
-  "datastructures",
-  "bitmanipulation",
-  "recursion",
-  "databases",
-  "brainteaser",
-  "arrays",
-];
+export enum Category {
+  Strings,
+  Algorithms,
+  DataStructures,
+  BitManipulation,
+  Recursion,
+  Databases,
+  Brainteaser,
+  Arrays,
+}
+
+export enum Language {
+  CoffeeScript,
+  Cpp,
+  CSharp,
+  Java,
+  JavaScript,
+  Php,
+  Python,
+  Ruby,
+  TypeScript,
+}
 
 export const DIFFICULTIES = ["easy", "medium", "hard"];

--- a/services/question-service/src/domain/question-schema.ts
+++ b/services/question-service/src/domain/question-schema.ts
@@ -15,10 +15,14 @@ export const QuestionRecordSchema = z.object({
 
 export const AddQuestionSchema = QuestionRecordSchema.omit({ id: true });
 
-export const GetQuestionSchema = QuestionRecordSchema.omit({
-  description: true,
-  link: true,
-}).partial();
+export const GetQuestionSchema = QuestionRecordSchema.extend({
+  getOne: z.boolean().optional(),
+})
+  .omit({
+    description: true,
+    link: true,
+  })
+  .partial();
 
 export const UpdateQuestionSchema = QuestionRecordSchema.omit({
   id: true,

--- a/services/question-service/src/entry-points/api/routes.ts
+++ b/services/question-service/src/entry-points/api/routes.ts
@@ -30,7 +30,11 @@ export default function defineRoutes(expressApp: express.Application) {
         difficulty: req.query.difficulty as Difficulty,
         categories: req.query.categories as Category[],
       });
-      res.json(response);
+      if (!req.query.getOne || !response) {
+        res.json(response);
+      } else {
+        res.json(response[Math.floor(Math.random() * response.length)]);
+      }
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
Changes:
1. Added Language as matching criteria
2. Changed string array to use enums
3. Added `getOne` field to `GET` question API to return only 1 random matching question when `true`
4. Integrated matching and question service by calling `GET` question API when match is found, and emitting to the two matching sockets


How to test:
1. create 2 questions using question api or /questions page with the same difficulty and category.
2. open postman websockets
Url: `http://localhost:6001`
Events: `reply`, `success`, `error`, `match` (events tab)
Message: (`register`), with body:
```
{
    "id": 123,
    "difficulty": "Medium",
    "category": "Algorithms",
    "language": "JavaScript"
}
```
3. connect and send on two connections, with different id (i.e. 123, 124)
4. should get response with question, as well as a roomId and language (SUCCESS)
5. change difficulty and/or category to one that would not match any question in the db
6. should return error message
