### PR TITLE
feat(matching): add matching by questionId

### DIFF
--- a/services/matching-service-rabbitmq/src/commons/types.ts
+++ b/services/matching-service-rabbitmq/src/commons/types.ts
@@ -1,8 +1,8 @@
 export type Match = {
-  socketId: string;
-  difficulty: Difficulty;
-  category: string;
   language: Language;
+  difficulty?: Difficulty;
+  category?: string;
+  questionId?: string;
 };
 
 export enum Difficulty {
@@ -12,6 +12,7 @@ export enum Difficulty {
 }
 
 export const categories = new Set([
+  "Strings",
   "Array",
   "Hash Table",
   "Linked List",

--- a/services/matching-service-rabbitmq/src/domain/match-usecase.ts
+++ b/services/matching-service-rabbitmq/src/domain/match-usecase.ts
@@ -8,33 +8,36 @@ import {
   getMessage,
   sendMessage,
 } from "../data-access/queue-repository";
-import { getQuestion } from "../services/question-service";
+import { getQuestion, getQuestionById } from "../services/question-service";
 
-import { assertQuestionExists } from "./match-validators";
+import {
+  assertQuestionExists,
+  assertQuestionExistsById,
+} from "./match-validators";
 
 const logger = pino();
-
 const TIMEOUT_DURATION = 1 * 60 * 1000; // 1 minute
 
 const generateQueueName = (
-  difficulty: Difficulty,
-  category: string,
   language: Language,
+  difficulty?: Difficulty,
+  category?: string,
+  questionId?: string,
 ) => {
-  const difficultyString = difficulty.toString();
-  const categoryString = category.toString();
-  const languageString = language.toString();
-
-  const matchName = difficultyString + categoryString + languageString;
-  logger.debug(`Generated queue name: ${matchName}`);
-  return matchName;
+  if (questionId) {
+    return `${questionId}${language}`;
+  }
+  if (difficulty && category) {
+    return `${difficulty}${category}${language}`;
+  }
+  throw new Error("Insufficient data to generate queue name");
 };
 
 const generatePayload = (language: Language, question: any) => {
   const roomId = uuidv4();
   const payload = { roomId, language: language.toString(), question };
 
-  logger.debug(`Generated payload: ${JSON.stringify(payload)}`);
+  logger.info(`Generated payload: ${JSON.stringify(payload)}`);
   return payload;
 };
 
@@ -44,7 +47,7 @@ const setMatchTimeout = (
   io: Server,
   socket: Socket,
 ) => {
-  logger.debug(`Setting match timeout for socketId ${socketId}`);
+  logger.info(`Setting match timeout for socketId ${socketId}`);
 
   setTimeout(async () => {
     const channel = await getChannelInstance();
@@ -64,16 +67,53 @@ const setMatchTimeout = (
   }, TIMEOUT_DURATION);
 };
 
+const disconnectWithError = (
+  socket: Socket,
+  io: Server,
+  message: string,
+  socketId: string,
+) => {
+  io.to(socketId).emit("error", message);
+  socket.disconnect();
+};
+
+const fetchQuestion = async (match: Match) => {
+  const { difficulty, category, questionId } = match;
+
+  if (questionId) {
+    const response = await getQuestionById(questionId);
+    if (!response || !response.ok) {
+      throw new Error(`No question found for questionId: ${questionId}`);
+    }
+    // eslint-disable-next-line @typescript-eslint/return-await
+    return await response.json();
+  }
+  if (difficulty && category) {
+    const params = new URLSearchParams({
+      difficulty: difficulty.toString(),
+      category: category.toString(),
+      getOne: "true",
+    });
+    const response = await getQuestion(params);
+    if (!response || !response.ok) {
+      throw new Error(`No question found for params: ${params}`);
+    }
+    // eslint-disable-next-line @typescript-eslint/return-await
+    return await response.json();
+  }
+  throw new Error("Missing required match parameters");
+};
+
 const processExistingMatch = async (
   existingMessage,
-  socketId,
   queueName,
   channel,
   io,
   socket,
   match: Match,
 ) => {
-  const { difficulty, category, language } = match;
+  const { id: socketId } = socket;
+
   const peerSocketId: any = existingMessage.content.toString();
   const peerSocket = io.sockets.sockets.get(peerSocketId);
 
@@ -102,22 +142,11 @@ const processExistingMatch = async (
 
   logger.info(`Match found for ${socketId}: ${peerSocketId}`);
 
-  // get question from question repo
-  const params = new URLSearchParams({
-    difficulty: difficulty.toString(),
-    category: category.toString(),
-    getOne: "true",
-  });
-  const response = await getQuestion(params);
+  const questionData = await fetchQuestion(match);
+  if (!questionData) return;
 
-  if (!response || !response.ok) {
-    logger.error(`No question found for params: ${params}`);
-    return;
-  }
-
-  const responseData = await response.json();
-  const payload = generatePayload(language, responseData);
-  logger.debug("Generated payload", payload);
+  const payload = generatePayload(match.language, questionData);
+  logger.info("Generated payload", payload);
 
   io.to(socketId).emit("match", payload);
   io.to(peerSocketId).emit("match", payload);
@@ -130,40 +159,42 @@ const processExistingMatch = async (
 
 export const findMatch = async (match: Match, io: Server, socket: Socket) => {
   const channel = await getChannelInstance();
-  const { difficulty, category, language, socketId } = match;
+  const { difficulty, category, language, questionId } = match;
 
-  logger.info(`Fetching question with ${difficulty}, ${category.toString()}`);
   try {
-    await assertQuestionExists(difficulty.toString(), category.toString());
+    if (questionId) {
+      await assertQuestionExistsById(questionId);
+    } else if (difficulty && category) {
+      await assertQuestionExists(difficulty.toString(), category);
+    } else {
+      throw new Error(
+        "Either provide difficulty, category, language or questionId, language.",
+      );
+    }
+
+    const queueName = generateQueueName(
+      language,
+      difficulty,
+      category,
+      questionId,
+    );
+
+    const existingMessage = await getMessage(queueName, channel);
+
+    if (existingMessage) {
+      await processExistingMatch(
+        existingMessage,
+        queueName,
+        channel,
+        io,
+        socket,
+        match,
+      );
+    } else {
+      await sendMessage(queueName, socket.id, channel);
+      setMatchTimeout(queueName, socket.id, io, socket);
+    }
   } catch (error) {
-    io.to(socketId).emit(
-      "error",
-      `Unable to find a question with difficulty: ${difficulty} and category: ${category}. Please try again with different parameters`,
-    );
-    socket.disconnect();
-  }
-
-  const queueName = generateQueueName(difficulty, category, language);
-
-  const existingMessage = await getMessage(queueName, channel);
-  if (existingMessage) {
-    logger.debug(
-      `Existing message found in queue ${queueName} for socketId ${socketId}`,
-    );
-    await processExistingMatch(
-      existingMessage,
-      socketId,
-      queueName,
-      channel,
-      io,
-      socket,
-      match,
-    );
-  } else {
-    logger.info(
-      `No match found for ${socketId} in ${queueName}. Adding to queue...`,
-    );
-    await sendMessage(queueName, socketId, channel);
-    setMatchTimeout(queueName, socketId, io, socket);
+    disconnectWithError(socket, io, error.message, socket.id);
   }
 };

--- a/services/matching-service-rabbitmq/src/entry-points/socket/controller.ts
+++ b/services/matching-service-rabbitmq/src/entry-points/socket/controller.ts
@@ -16,7 +16,7 @@ export const defineEventListeners = (io: Server) => {
       logger.info(`Received register event from ${socket.id}`);
       logger.debug(`Register data: ${JSON.stringify(data)}`);
 
-      // validate inputs
+      // Validate inputs for both match types
       const isValid = await validateInput(data, socket);
       if (!isValid) {
         logger.warn(`Input validation failed for socket id: ${socket.id}`);
@@ -24,7 +24,7 @@ export const defineEventListeners = (io: Server) => {
       }
 
       logger.info(`Input validation succeeded for socket id: ${socket.id}`);
-      await findMatch({ ...data, socketId: socket.id }, io, socket);
+      await findMatch(data, io, socket);
     });
 
     socket.on("disconnect", () => {

--- a/services/matching-service-rabbitmq/src/entry-points/socket/validators.ts
+++ b/services/matching-service-rabbitmq/src/entry-points/socket/validators.ts
@@ -1,17 +1,34 @@
 import type { Socket } from "socket.io";
 
-import { Difficulty, Language, type Match } from "../../commons/types";
+import type { Match } from "../../commons/types";
+import { categories, Difficulty, Language } from "../../commons/types";
 
 export const validateInput = async (
   msg: Match,
   socket: Socket,
 ): Promise<boolean> => {
-  if (Difficulty[msg.difficulty] === undefined) {
+  if (msg.questionId) {
+    if (msg.language !== undefined && Language[msg.language] === undefined) {
+      socket.emit("error", "Invalid Language!");
+      return false;
+    }
+    return true;
+  }
+
+  if (
+    msg.difficulty !== undefined &&
+    Difficulty[msg.difficulty] === undefined
+  ) {
     socket.emit("error", "Invalid Difficulty!");
     return false;
   }
 
-  if (Language[msg.language] === undefined) {
+  if (msg.category === undefined || !categories.has(msg.category)) {
+    socket.emit("error", "Invalid Category!");
+    return false;
+  }
+
+  if (msg.language !== undefined && Language[msg.language] === undefined) {
     socket.emit("error", "Invalid Language!");
     return false;
   }

--- a/services/matching-service-rabbitmq/src/services/question-service.ts
+++ b/services/matching-service-rabbitmq/src/services/question-service.ts
@@ -5,9 +5,26 @@ export const getQuestion = async (
 ): Promise<Response> => {
   const logger = pino();
   try {
-    logger.info(`Getting question from questions repository...`);
+    logger.info(`GET /question/?${params.toString()}`);
     const res = await fetch(
       `http://question-service:5001/question/?${params.toString()}`,
+    );
+
+    return res;
+  } catch (error) {
+    logger.error("Error fetching question from question repo", error.message);
+    throw error;
+  }
+};
+
+export const getQuestionById = async (
+  questionId: string,
+): Promise<Response> => {
+  const logger = pino();
+  try {
+    logger.info(`GET /question/${questionId}`);
+    const res = await fetch(
+      `http://question-service:5001/question/${questionId}`,
     );
 
     return res;


### PR DESCRIPTION
## Summary
- In lieu of the question-of-the-day feature where users are matched by `questionId` and `language`, this PR adds support for this new matching request
- Refactor `matching-service` to throw errors and have a single point of error emission in `disconnectWithError` for more robust error-handling