### PR TITLE
matching service enhancements

### DIFF
--- a/services/frontend/src/app/matching/page.tsx
+++ b/services/frontend/src/app/matching/page.tsx
@@ -18,14 +18,13 @@ const page = () => {
   const URL = "http://localhost:6001";
 
   const socketRef = useRef<Socket>();
-  const [matchPending, setMatchPending] = useState<boolean>(false);
-
+  const [queueTime, setQueueTime] = useState<number>();
   useEffect(() => {
     const socket = io(URL, { autoConnect: false });
 
     socket.on("error", (errorMessage: string) => {
       socketRef.current?.disconnect();
-      setMatchPending(false);
+      setQueueTime(undefined);
       const notificationPayload = {
         type: NotificationType.ERROR,
         value: errorMessage,
@@ -49,14 +48,14 @@ const page = () => {
         ...values,
       };
       socketRef.current.emit("register", request);
-      setMatchPending(true);
+      setQueueTime(Date.now());
     }
   };
 
   const handleLeaveQueue = () => {
-    if (socketRef.current && matchPending) {
+    if (socketRef.current && queueTime) {
       socketRef.current?.disconnect();
-      setMatchPending(false);
+      setQueueTime(undefined);
     }
   };
 
@@ -70,7 +69,8 @@ const page = () => {
             <MatchingForm
               handleLeaveQueue={handleLeaveQueue}
               onSubmit={handleMatchingSubmit}
-              matchPending={matchPending}
+              matchPending={queueTime !== undefined}
+              queueTime={queueTime}
             />
           </div>
         </div>

--- a/services/matching-service-rabbitmq/src/entry-points/socket/controller.ts
+++ b/services/matching-service-rabbitmq/src/entry-points/socket/controller.ts
@@ -27,7 +27,11 @@ export const defineEventListeners = (io: Server) => {
       await findMatch(data, io, socket);
     });
 
-    socket.on("disconnect", () => {
+    socket.on("disconnecting", () => {
+      io.to(socket.id).emit(
+        "error",
+        "Connection lost. Please try again in a while.",
+      );
       logger.warn(`User disconnected with socket id: ${socket.id}`);
     });
   });


### PR DESCRIPTION
Changelog:
 - Add timer for matching on frontend
 - ~~Change matching-service to emit **timeout** as `error` event instead of `timeout` event to be reflected on frontend~~ I realised this change was also made in my previous PR so not this PR anm